### PR TITLE
Ability to specify custom Fader color

### DIFF
--- a/AAShareBubbles/AAShareBubbles.h
+++ b/AAShareBubbles/AAShareBubbles.h
@@ -62,6 +62,9 @@ typedef enum AAShareBubbleType : int {
 // The fader view alpha, by default is 0.15
 @property(nonatomic, assign) CGFloat faderAlpha;
 
+// The fader view background color, default is black
+@property (nonatomic, strong) UIColor *faderColor;
+
 @property (nonatomic, assign) int facebookBackgroundColorRGB;
 @property (nonatomic, assign) int twitterBackgroundColorRGB;
 @property (nonatomic, assign) int mailBackgroundColorRGB;

--- a/AAShareBubbles/AAShareBubbles.m
+++ b/AAShareBubbles/AAShareBubbles.m
@@ -36,6 +36,7 @@
         self.bubbleRadius = 40;
         self.parentView = inView;
         self.faderAlpha = 0.15;
+        self.faderColor = [UIColor blackColor];
         
         self.facebookBackgroundColorRGB = 0x3c5a9a;
         self.twitterBackgroundColorRGB = 0x3083be;
@@ -83,7 +84,7 @@
         
         // Create background
         faderView = [[UIView alloc] initWithFrame:self.parentView.bounds];
-        faderView.backgroundColor = [UIColor blackColor];
+        faderView.backgroundColor = self.faderColor;
         faderView.alpha = 0.0f;
         UITapGestureRecognizer *tapges = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(shareViewBackgroundTapped:)];
         [faderView addGestureRecognizer:tapges];


### PR DESCRIPTION
This PR adds the ability to specify a custom fader color.

There is a new faderColor property.  Set that to a UIColor and it will change the fader color appropriately when rendered.  The faderAlpha property still works as it did before.
